### PR TITLE
Bug iOS on Blur

### DIFF
--- a/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/BlurProtectionManager.cs
+++ b/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/BlurProtectionManager.cs
@@ -16,7 +16,7 @@ internal class BlurProtectionManager
                 if (enabled)
                     EnableBlurScreenProtection(window, style);
                 else
-                    DisableBlurScreenProtection();
+                    DisableBlurScreenProtection(window);
             }
             catch (Exception ex)
             {
@@ -28,7 +28,7 @@ internal class BlurProtectionManager
         {
             try
             {
-                DisableBlurScreenProtection();
+                DisableBlurScreenProtection(window);
             }
             catch (Exception ex)
             {
@@ -49,11 +49,11 @@ internal class BlurProtectionManager
         }
     }
 
-    internal static void DisableBlur()
+    internal static void DisableBlur(UIWindow? window)
     {
         try
         {
-            DisableBlurScreenProtection();
+            DisableBlurScreenProtection(window);
         }
         catch (Exception ex)
         {
@@ -77,15 +77,23 @@ internal class BlurProtectionManager
             {
                 Frame = window.Frame
             };
-        
+
             window.AddSubview(_blurBackground);
         }
     }
 
-    private static void DisableBlurScreenProtection()
+    private static void DisableBlurScreenProtection(UIWindow? window)
     {
-        _blurBackground?.RemoveFromSuperview();
-
-        _blurBackground = null;
+        if (window is not null)
+        {
+            foreach (var subview in window.Subviews)
+            {
+                if (subview is UIVisualEffectView)
+                {
+                    subview.RemoveFromSuperview();
+                }
+            }
+            _blurBackground = null;
+        }
     }
 }

--- a/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/ScreenRecordingProtectionManager.cs
+++ b/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/ScreenRecordingProtectionManager.cs
@@ -19,21 +19,21 @@ internal class ScreenRecordingProtectionManager
                         if (enabled)
                             EnableScreenRecordingProtection(withColor, window);
                         else
-                            DisableScreenRecordingProtection();
+                            DisableScreenRecordingProtection(window);
                     }
                 }
                 else
-                    DisableScreenRecordingProtection();
+                    DisableScreenRecordingProtection(window);
 #elif NET7_0
                 if (UIScreen.MainScreen.Captured)
                 {
                     if (enabled)
                         EnableScreenRecordingProtection(withColor, window);
                     else
-                        DisableScreenRecordingProtection();
+                        DisableScreenRecordingProtection(window);
                 }
                 else
-                    DisableScreenRecordingProtection();
+                    DisableScreenRecordingProtection(window);
 #endif
             }
             catch (Exception ex)
@@ -51,9 +51,9 @@ internal class ScreenRecordingProtectionManager
             BlurProtectionManager.EnableBlur(window, ThemeStyle.Light);
     }
 
-    private static void DisableScreenRecordingProtection()
+    private static void DisableScreenRecordingProtection(UIWindow? window)
     {
-        BlurProtectionManager.DisableBlur();
+        BlurProtectionManager.DisableBlur(window);
 
         ColorProtectionManager.DisableColor();
     }


### PR DESCRIPTION
when the application has screen security activated, several views are added to the super view when focus is lost. Only on iOS. The fix is ​​to loop over the views in order to remove the UIVisualEffectView