### PR TITLE
iOS16 fix for CALayer Invalid

### DIFF
--- a/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/ScreenshotProtectionManager.cs
+++ b/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/ScreenshotProtectionManager.cs
@@ -69,7 +69,7 @@ internal class ScreenshotProtectionManager
                 {
                     if (window is not null)
                     {
-                        _secureTextField ??= new()
+                        _secureTextField = new()
                         {
                             UserInteractionEnabled = false
                         };


### PR DESCRIPTION
- Set _secureTextField to new every time instead of ??=
- This matches behavior in the 17.0 path