### PR TITLE
Dotnet10 Fix blur

### DIFF
--- a/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/BlurProtectionManager.cs
+++ b/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/BlurProtectionManager.cs
@@ -91,47 +91,58 @@ internal class BlurProtectionManager
         }
     }
 
-    private static void EnableBlurScreenProtection(UIWindow? window = null, ThemeStyle? style = null)
-    {
-        if (window is null)
-            return;
-
-        MainThread.BeginInvokeOnMainThread(() =>
-        {
-            var blurEffectStyle = style switch
-            {
-                ThemeStyle.Light => UIBlurEffectStyle.Light,
-                _ => UIBlurEffectStyle.Dark
-            };
-
-            using var blurEffect = UIBlurEffect.FromStyle(blurEffectStyle);
-
-            _blurBackground = new UIVisualEffectView(blurEffect)
-            {
-                Frame = window.Frame
-            };
-
-            window.AddSubview(_blurBackground);
+    private static void EnableBlurScreenProtection(UIWindow? window = null, ThemeStyle? style = null) {
+        MainThread.BeginInvokeOnMainThread(() => {
+            AddBlurScreenProtection(window,style);
         });
+    }
+
+    private static void AddBlurScreenProtection(UIWindow? window = null, ThemeStyle? style = null) {
+        var target = window ?? IOSHelpers.GetWindow();
+        if (target is null)
+            return;
+        
+        DisableBlurScreenProtection(target);
+        var blurEffectStyle = style switch
+        {
+            ThemeStyle.Light => UIBlurEffectStyle.Light,
+            _ => UIBlurEffectStyle.Dark
+        };
+
+        using var blurEffect = UIBlurEffect.FromStyle(blurEffectStyle);
+
+        _blurBackground = new UIVisualEffectView(blurEffect)
+        {
+            Frame = target.Bounds,
+            AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight
+        };
+
+        target.AddSubview(_blurBackground);
     }
 
     private static void DisableBlurScreenProtection(UIWindow? window)
     {
-        if (window is null)
-            return;
-
-        MainThread.BeginInvokeOnMainThread(() =>
-        {
-            foreach (var subview in window.Subviews)
-            {
-                if (subview is UIVisualEffectView)
-                {
-                    subview.RemoveFromSuperview();
-                }
-            }
-
-            _blurBackground = null;
+        MainThread.BeginInvokeOnMainThread(() => {
+            RemoveBlurScreenProtection(window);
         });
+    }
+
+    private static void RemoveBlurScreenProtection(UIWindow? window) {
+        _blurBackground?.RemoveFromSuperview();
+        _blurBackground = null;
+            
+        var target = window ?? IOSHelpers.GetWindow();
+
+        if (target is null)
+            return;
+            
+        foreach (var subview in target.Subviews)
+        {
+            if (subview is UIVisualEffectView)
+            {
+                subview.RemoveFromSuperview();
+            }
+        }
     }
 
     private static void DisposeObservers()

--- a/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/BlurProtectionManager.cs
+++ b/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/BlurProtectionManager.cs
@@ -54,10 +54,7 @@ internal class BlurProtectionManager
             {
                 try
                 {
-                    MainThread.BeginInvokeOnMainThread(() =>
-                    {
-                        DisableBlurScreenProtection(window);
-                    });
+                    MainThread.BeginInvokeOnMainThread(() => { DisableBlurScreenProtection(window); });
                 }
                 catch (Exception ex)
                 {
@@ -91,17 +88,20 @@ internal class BlurProtectionManager
         }
     }
 
-    private static void EnableBlurScreenProtection(UIWindow? window = null, ThemeStyle? style = null) {
-        MainThread.BeginInvokeOnMainThread(() => {
-            AddBlurScreenProtection(window,style);
+    private static void EnableBlurScreenProtection(UIWindow? window = null, ThemeStyle? style = null)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            AddBlurScreenProtection(window, style);
         });
     }
 
-    private static void AddBlurScreenProtection(UIWindow? window = null, ThemeStyle? style = null) {
+    private static void AddBlurScreenProtection(UIWindow? window = null, ThemeStyle? style = null)
+    {
         var target = window ?? IOSHelpers.GetWindow();
         if (target is null)
             return;
-        
+
         DisableBlurScreenProtection(target);
         var blurEffectStyle = style switch
         {
@@ -122,20 +122,22 @@ internal class BlurProtectionManager
 
     private static void DisableBlurScreenProtection(UIWindow? window)
     {
-        MainThread.BeginInvokeOnMainThread(() => {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
             RemoveBlurScreenProtection(window);
         });
     }
 
-    private static void RemoveBlurScreenProtection(UIWindow? window) {
+    private static void RemoveBlurScreenProtection(UIWindow? window)
+    {
         _blurBackground?.RemoveFromSuperview();
         _blurBackground = null;
-            
+
         var target = window ?? IOSHelpers.GetWindow();
 
         if (target is null)
             return;
-            
+
         foreach (var subview in target.Subviews)
         {
             if (subview is UIVisualEffectView)

--- a/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/BlurProtectionManager.cs
+++ b/Plugin.Maui.ScreenSecurity/Platforms/iOS/Protections/BlurProtectionManager.cs
@@ -102,7 +102,7 @@ internal class BlurProtectionManager
         if (target is null)
             return;
 
-        DisableBlurScreenProtection(target);
+        RemoveBlurScreenProtection(target);
         var blurEffectStyle = style switch
         {
             ThemeStyle.Light => UIBlurEffectStyle.Light,
@@ -131,6 +131,7 @@ internal class BlurProtectionManager
     private static void RemoveBlurScreenProtection(UIWindow? window)
     {
         _blurBackground?.RemoveFromSuperview();
+        _blurBackground?.Dispose();
         _blurBackground = null;
 
         var target = window ?? IOSHelpers.GetWindow();


### PR DESCRIPTION
Issue: With the screen blur on, enable auto-rotation. Blur an app in portrait, auto-rotate to landscape, the blur only covers half the screen
- Fix: Change the visual effect for blur to use target.Bounds with an AutoresizingMask to handle auto-rotation

Issue: After backgrounding an app with blur on, returning to it does not dismiss the blur
- Fix: Improved handling to remove
  - Always remove the blur even if the window is null.
  - Call remove before add ( Similar to Image Protection)
  - Window should have come from IOSHelpers.GetWindow(), if it didn't resolve in time, try again.